### PR TITLE
Adding maxgap to interpolation function

### DIFF
--- a/R/make_smoothed_data.R
+++ b/R/make_smoothed_data.R
@@ -288,7 +288,9 @@ regress_data <- function(data, pupil1, pupil2) {
 #' @param data a PupillometryR dataframe
 #' @param pupil Column name for pupil data to be interpolated
 #' @param type string indicating linear or cubic interpolation to be performed.
-#'
+#' @param maxgap numeric value specifying the maximum gap size (number of consecutive NAs) to interpolate. 
+#'        Default is Inf (interpolates gaps of any length).
+#' 
 #' @examples
 #' Sdata <- make_pupillometryr_data(data = pupil_data,
 #' subject = ID,
@@ -310,7 +312,7 @@ regress_data <- function(data, pupil1, pupil2) {
 #' @export
 #' @return interpolated pupillometry data
 
-interpolate_data <- function(data, pupil, type = c('linear', 'cubic')){
+interpolate_data <- function(data, pupil, type = c('linear', 'cubic'), maxgap = Inf){
 
   pupil <- deparse(substitute(pupil))
   if('PupillometryR' %in% class(data) == FALSE){
@@ -328,11 +330,11 @@ interpolate_data <- function(data, pupil, type = c('linear', 'cubic')){
 
   #make functions
   .spline <- function(x){
-    x <- zoo::na.spline(x, na.rm = F)
+    x <- zoo::na.spline(x, na.rm = F, maxgap = maxgap)
     return(x)
   }
   .approx <- function(x){
-    x <- zoo::na.approx(x, na.rm = F, rule = 2)
+    x <- zoo::na.approx(x, na.rm = F, rule = 2, maxgap = maxgap)
     return(x)
   }
   #interpolate


### PR DESCRIPTION
As mentioned in #32, I propose adding a parameter to control the number of interpolated values. I've introduced a new parameter, `maxgap`, which leverages functionality already available in the zoo package. By default, maxgap is set to Inf, so it doesn't alter the default behavior of pupillometryR. However, users can adjust it as needed to limit interpolation in cases of long gaps.